### PR TITLE
Add web vitals with attribution instrumentation

### DIFF
--- a/demo/src/client/faro/initialize.ts
+++ b/demo/src/client/faro/initialize.ts
@@ -18,6 +18,7 @@ export function initializeFaro(): Faro {
     instrumentations: [
       ...getWebInstrumentations({
         captureConsole: true,
+        captureWebVitalsAttribution: true,
       }),
 
       new TracingInstrumentation(),

--- a/packages/web-sdk/src/config/getWebInstrumentations.ts
+++ b/packages/web-sdk/src/config/getWebInstrumentations.ts
@@ -7,6 +7,7 @@ import {
   SessionInstrumentation,
   ViewInstrumentation,
   WebVitalsInstrumentation,
+  WebVitalsWithAttributionInstrumentation,
 } from '../instrumentations';
 
 import type { GetWebInstrumentationsOptions } from './types';
@@ -14,7 +15,6 @@ import type { GetWebInstrumentationsOptions } from './types';
 export function getWebInstrumentations(options: GetWebInstrumentationsOptions = {}): Instrumentation[] {
   const instrumentations: Instrumentation[] = [
     new ErrorsInstrumentation(),
-    new WebVitalsInstrumentation(),
     new SessionInstrumentation(),
     new ViewInstrumentation(),
   ];
@@ -30,6 +30,12 @@ export function getWebInstrumentations(options: GetWebInstrumentationsOptions = 
         disabledLevels: options.captureConsoleDisabledLevels,
       })
     );
+  }
+
+  if (options.captureWebVitalsAttribution === true) {
+    instrumentations.push(new WebVitalsWithAttributionInstrumentation());
+  } else {
+    instrumentations.push(new WebVitalsInstrumentation());
   }
 
   return instrumentations;

--- a/packages/web-sdk/src/config/types.ts
+++ b/packages/web-sdk/src/config/types.ts
@@ -9,4 +9,5 @@ export interface GetWebInstrumentationsOptions {
   captureConsole?: boolean;
   captureConsoleDisabledLevels?: LogLevel[];
   enablePerformanceInstrumentation?: boolean;
+  captureWebVitalsAttribution?: boolean;
 }

--- a/packages/web-sdk/src/index.ts
+++ b/packages/web-sdk/src/index.ts
@@ -14,6 +14,7 @@ export {
   parseStacktrace,
   ViewInstrumentation,
   WebVitalsInstrumentation,
+  WebVitalsWithAttributionInstrumentation,
   SessionInstrumentation,
   PerformanceInstrumentation,
 } from './instrumentations';

--- a/packages/web-sdk/src/instrumentations/index.ts
+++ b/packages/web-sdk/src/instrumentations/index.ts
@@ -16,6 +16,8 @@ export { ViewInstrumentation } from './view';
 
 export { WebVitalsInstrumentation } from './webVitals';
 
+export { WebVitalsWithAttributionInstrumentation } from './webVitalsWithAttribution';
+
 export {
   PersistentSessionsManager,
   VolatileSessionsManager,

--- a/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/index.ts
+++ b/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/index.ts
@@ -1,0 +1,1 @@
+export { WebVitalsWithAttributionInstrumentation } from './instrumentation'

--- a/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/instrumentation.test.ts
+++ b/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/instrumentation.test.ts
@@ -1,0 +1,253 @@
+import type { MetricWithAttribution } from 'web-vitals/attribution'
+
+import { initializeFaro, MeasurementEvent, TransportItem } from '@grafana/faro-core';
+import { mockConfig, MockTransport } from '@grafana/faro-core/src/testUtils';
+
+
+import { WebVitalsWithAttributionInstrumentation } from './instrumentation';
+
+jest.mock('web-vitals/attribution', () => {
+    type MetricName =  MetricWithAttribution['name'];
+    type MetricAttribution = MetricWithAttribution['attribution'];
+
+    function createMetric(name: MetricName, attribution: MetricAttribution): MetricWithAttribution {
+        return {
+            name,
+            value: 0.1,
+            rating: 'good',
+            delta: 0.1,
+            id: 'id',
+            entries: [],
+            navigationType: 'navigate',
+            attribution,
+        };
+    }
+
+    return {
+        onCLS: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('CLS', {
+                largestShiftValue: 0.1,
+                largestShiftTime: 0.1,
+                loadState: 'load',
+                largestShiftTarget: 'target',
+                largestShiftEntry: {
+                    value: 0.1,
+                },
+            }));
+        },
+        onFCP: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('FCP', {
+                firstByteToFCP: 0.1,
+                timeToFirstByte: 0.1,
+                loadState: 'load',
+            }));
+        },
+        onFID: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('FID', {
+                eventTime: 0.1,
+                eventTarget: 'target',
+                eventType: 'type',
+                loadState: 'load',
+            }));
+        },
+        onLCP: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('LCP', {
+                elementRenderDelay: 0.1,
+                resourceLoadDelay: 0.1,
+                resourceLoadTime: 0.1,
+                timeToFirstByte: 0.1,
+                element: 'element',
+            }));
+        },
+        onTTFB: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('TTFB', {
+                dnsTime: 0.1,
+                // intentionally removed to test when not present
+                // connectionTime: 0.1,
+                requestTime: 0.1,
+                waitingTime: 0.1,
+            }));
+        },
+        onINP: (cb: (metric: MetricWithAttribution) => void) => {
+            cb(createMetric('INP', {
+                eventTime: 0.1,
+                eventTarget: 'target',
+                eventType: 'type',
+                loadState: 'load',
+            }));
+        },
+    };
+});
+
+describe('WebVitalsWithAttributionInstrumentation', () => {
+    it('send cls metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const clsEvent = findTransportItemByMetricName(transport, 'cls');
+
+        expect(clsEvent).not.toBeUndefined()
+
+        expect(clsEvent.payload.values).toMatchObject({
+            cls: 0.1,
+            largest_shift_value: 0.1,
+            largest_shift_time: 0.1,
+            largest_shift_entry: 0.1,
+        })
+
+        expect(clsEvent.payload.context).toMatchObject({
+            largest_shift_target: 'target',
+            load_state: 'load',
+            rating: 'good',
+        })
+    });
+
+    it('send fcp metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const fcpEvent = findTransportItemByMetricName(transport, 'fcp');
+
+        expect(fcpEvent).not.toBeUndefined()
+
+        expect(fcpEvent.payload.values).toMatchObject({
+            fcp: 0.1,
+            first_byte_to_fcp: 0.1,
+            time_to_first_byte: 0.1,
+        })
+
+        expect(fcpEvent.payload.context).toMatchObject({
+            rating: 'good',
+            load_state: 'load',
+        })
+    });
+
+    it('send fid metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const fidEvent = findTransportItemByMetricName(transport, 'fid');
+
+        expect(fidEvent).not.toBeUndefined()
+
+        expect(fidEvent.payload.values).toMatchObject({
+            fid: 0.1,
+            event_time: 0.1,
+        })
+
+        expect(fidEvent.payload.context).toMatchObject({
+            rating: 'good',
+            event_target: 'target',
+            event_type: 'type',
+            load_state: 'load',
+        })
+    });
+
+    it('send inp metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const inpEvent = findTransportItemByMetricName(transport, 'inp');
+
+        expect(inpEvent).not.toBeUndefined()
+
+        expect(inpEvent.payload.values).toMatchObject({
+            inp: 0.1,
+            event_time: 0.1,
+        })
+
+        expect(inpEvent.payload.context).toMatchObject({
+            rating: 'good',
+            event_target: 'target',
+            event_type: 'type',
+            load_state: 'load',
+        })
+    });
+
+    it('send lcp metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const lcpEvent = findTransportItemByMetricName(transport, 'lcp');
+
+        expect(lcpEvent).not.toBeUndefined()
+
+        expect(lcpEvent.payload.values).toMatchObject({
+            lcp: 0.1,
+            element_render_delay: 0.1,
+            resource_load_delay: 0.1,
+            resource_load_time: 0.1,
+            time_to_first_byte: 0.1,
+        })
+
+        expect(lcpEvent.payload.context).toMatchObject({
+            rating: 'good',
+            element: 'element',
+        })
+    });
+
+    it('send ttfb metrics correctly', () => {
+        const transport = new MockTransport();
+
+        initializeFaro(
+            mockConfig({
+                transports: [transport],
+                instrumentations: [new WebVitalsWithAttributionInstrumentation()],
+            })
+        );
+
+        const ttfbEvent = findTransportItemByMetricName(transport, 'ttfb');
+
+        expect(ttfbEvent).not.toBeUndefined()
+
+        expect(ttfbEvent.payload.values).toMatchObject({
+            ttfb: 0.1,
+            dns_time: 0.1,
+            // intentionally removed to test when not present
+            // connection_time: 0.1,
+            request_time: 0.1,
+            waiting_time: 0.1,
+        })
+
+        expect(ttfbEvent.payload.context).toMatchObject({
+            rating: 'good',
+        })
+    });
+
+    function findTransportItemByMetricName(transport: MockTransport, name: string): TransportItem<MeasurementEvent> {
+        return transport.items.find(
+            (item) =>
+                (item as TransportItem<MeasurementEvent>).payload.values?.[name]
+        ) as TransportItem<MeasurementEvent>
+    }
+});

--- a/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/instrumentation.ts
+++ b/packages/web-sdk/src/instrumentations/webVitalsWithAttribution/instrumentation.ts
@@ -1,0 +1,128 @@
+import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB } from 'web-vitals/attribution'
+import type { Metric } from 'web-vitals/attribution'
+
+import { BaseInstrumentation, VERSION } from '@grafana/faro-core';
+import type  { MeasurementEvent, PushMeasurementOptions } from '@grafana/faro-core'
+
+type Values = MeasurementEvent['values']
+type Context = Required<PushMeasurementOptions>['context']
+
+export class WebVitalsWithAttributionInstrumentation extends BaseInstrumentation {
+  readonly name = '@grafana/faro-web-sdk:instrumentation-web-vitals-with-attribution'
+  readonly version = VERSION
+
+  initialize(): void {
+    this.logDebug('Initializing');
+    this.measureCLS()
+    this.measureFCP()
+    this.measureFID()
+    this.measureINP()
+    this.measureLCP()
+    this.measureTTFB()
+  }
+
+  private measureCLS(): void {
+    onCLS((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'largest_shift_entry', metric.attribution.largestShiftEntry?.value)
+      this.addIfPresent(values, 'largest_shift_value', metric.attribution.largestShiftValue)
+      this.addIfPresent(values, 'largest_shift_time', metric.attribution.largestShiftTime)
+
+      const context = this.buildInitialContext(metric)
+      this.addIfPresent(context, 'load_state', metric.attribution.loadState)
+      this.addIfPresent(context, 'largest_shift_target', metric.attribution.largestShiftTarget)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private measureFCP(): void {
+    onFCP((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'first_byte_to_fcp', metric.attribution.firstByteToFCP)
+      this.addIfPresent(values, 'time_to_first_byte', metric.attribution.timeToFirstByte)
+
+      const context = this.buildInitialContext(metric)
+      this.addIfPresent(context, 'load_state', metric.attribution.loadState)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private measureFID(): void {
+    onFID((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'event_time', metric.attribution.eventTime)
+
+      const context = this.buildInitialContext(metric)
+      this.addIfPresent(context, 'event_target', metric.attribution.eventTarget)
+      this.addIfPresent(context, 'event_type', metric.attribution.eventType)
+      this.addIfPresent(context, 'load_state', metric.attribution.loadState)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private measureINP(): void {
+    onINP((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'event_time', metric.attribution.eventTime)
+
+      const context = this.buildInitialContext(metric)
+      this.addIfPresent(context, 'event_target', metric.attribution.eventTarget)
+      this.addIfPresent(context, 'event_type', metric.attribution.eventType)
+      this.addIfPresent(context, 'load_state', metric.attribution.loadState)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private measureLCP(): void {
+    onLCP((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'element_render_delay', metric.attribution.elementRenderDelay)
+      this.addIfPresent(values, 'resource_load_delay', metric.attribution.resourceLoadDelay)
+      this.addIfPresent(values, 'resource_load_time', metric.attribution.resourceLoadTime)
+      this.addIfPresent(values, 'time_to_first_byte', metric.attribution.timeToFirstByte)
+
+      const context = this.buildInitialContext(metric)
+      this.addIfPresent(context, 'element', metric.attribution.element)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private measureTTFB(): void {
+    onTTFB((metric) => {
+      const values = this.buildInitialValues(metric)
+      this.addIfPresent(values, 'dns_time', metric.attribution.dnsTime)
+      this.addIfPresent(values, 'connection_time', metric.attribution.connectionTime)
+      this.addIfPresent(values, 'request_time', metric.attribution.requestTime)
+      this.addIfPresent(values, 'waiting_time', metric.attribution.waitingTime)
+
+      const context = this.buildInitialContext(metric)
+
+      this.pushMeasurement(values, context)
+    })
+  }
+
+  private buildInitialValues(metric: Metric): Values {
+    const indicator = metric.name.toLowerCase()
+    return { [indicator]: metric.value }
+  }
+
+  private buildInitialContext(metric: Metric): Context {
+    return { rating: metric.rating }
+  }
+
+  private pushMeasurement(values: Values, context: Context): void {
+    const type = 'web-vitals'
+    this.api.pushMeasurement({ type, values }, { context })
+  }
+
+  private addIfPresent(source: Values | Context, key: string, metric?: number | string): void {
+    if (metric) {
+      source[key] = metric
+    }
+  }
+}


### PR DESCRIPTION
## Why

<!-- Add a clear and concise description of why that changes are needed. -->
This is a feature that will be useful as discussed in this issue https://github.com/grafana/faro-web-sdk/issues/593


## What

<!-- Add a clear and concise description of what you changed. -->
- I created a web vitals instrumentation with attribution
- I created a `captureWebVitalsAttribution` option in the `getWebInstrumentations` function to decide which vitals instrumentation to load

## Links

<!-- Add issues the PR solves or other useful links here. -->
https://github.com/grafana/faro-web-sdk/issues/593

## Checklist

- [x] Tests added
- [ ] Changelog updated
- [ ] Documentation updated
